### PR TITLE
Adding and updating city tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "go.inferGopath": false
+}

--- a/citysummary/client_test.go
+++ b/citysummary/client_test.go
@@ -64,7 +64,7 @@ func TestCitySummary(t *testing.T) {
 	assert.NotNil(t, property.Results.Location)
 
 	addressLookup := &firststreet.Lookup{
-		Address: "1327 Autumn Drive Fernandina Beach FL",
+		Address: "Fernandina Beach FL",
 	}
 
 	property, err = c.Lookup(addressLookup)

--- a/hurricane/client_test.go
+++ b/hurricane/client_test.go
@@ -43,9 +43,8 @@ func hurricaneCityHandler() http.HandlerFunc {
 }
 
 func TestHurricaneLookupProperty(t *testing.T) {
-	testutil.Once.Do(func() {
-		testutil.StartServer(hurricanePropertyHandler())
-	})
+	testutil.StartServer(hurricanePropertyHandler())
+
 	testBackend.URL = testutil.ServerAddr
 	c := &Client{
 		B: testBackend,
@@ -89,22 +88,21 @@ func TestHurricaneLookupProperty(t *testing.T) {
 }
 
 func TestHurricaneLookupCity(t *testing.T) {
-	testutil.Once.Do(func() {
-		testutil.StartServer(hurricaneCityHandler())
-	})
+	testutil.StartServer(hurricaneCityHandler())
+
 	testBackend.URL = testutil.ServerAddr
 	c := &Client{
 		B: testBackend,
 	}
 
 	fsidLookup := &firststreet.Lookup{
-		FSID: 450350219571,
+		FSID: 4550875,
 	}
 
 	frd, err := c.Lookup(firststreet.CityLocationType, fsidLookup)
 	assert.Nil(t, err)
 	assert.NotNil(t, frd)
-	assert.Equal(t, frd.FSID, int64(450350219571))
+	assert.Equal(t, frd.FSID, int64(4550875))
 	assert.NotNil(t, frd.Results)
 
 	fsidLookupBad := &firststreet.Lookup{}
@@ -119,16 +117,16 @@ func TestHurricaneLookupCity(t *testing.T) {
 	frd, err = c.Lookup(firststreet.CityLocationType, latLngLookup)
 	assert.Nil(t, err)
 	assert.NotNil(t, frd)
-	assert.Equal(t, frd.FSID, int64(450350219571))
+	assert.Equal(t, frd.FSID, int64(4550875))
 	assert.NotNil(t, frd.Results)
 
 	addressLookup := &firststreet.Lookup{
-		Address: "1327 Autumn Drive Fernandina Beach FL",
+		Address: "Fernandina Beach FL",
 	}
 
 	frd, err = c.Lookup(firststreet.CityLocationType, addressLookup)
 	assert.Nil(t, err)
 	assert.NotNil(t, frd)
-	assert.Equal(t, frd.FSID, int64(450350219571))
+	assert.Equal(t, frd.FSID, int64(4550875))
 	assert.NotNil(t, frd.Results)
 }

--- a/marketvalueimpact/client_test.go
+++ b/marketvalueimpact/client_test.go
@@ -29,10 +29,21 @@ func marketValueImpactPropertyHandler() http.HandlerFunc {
 	})
 }
 
-func TestMVILookup(t *testing.T) {
-	testutil.Once.Do(func() {
-		testutil.StartServer(marketValueImpactPropertyHandler())
+func marketValueImpactCityHandler() http.HandlerFunc {
+	mviSample, err := ioutil.ReadFile(testutil.GetDirectoryPath() + "/fixtures/mvi-city.json")
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// nolint
+		w.Write(mviSample)
 	})
+}
+
+func TestMVIPropertyLookup(t *testing.T) {
+	testutil.StartServer(marketValueImpactPropertyHandler())
+
 	testBackend.URL = testutil.ServerAddr
 	c := &Client{
 		B: testBackend,
@@ -71,6 +82,51 @@ func TestMVILookup(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, mvi)
 	assert.Equal(t, mvi.FSID, int64(450350219571))
+	assert.NotNil(t, mvi.Results)
+
+}
+
+func TestMVICityLookup(t *testing.T) {
+	testutil.StartServer(marketValueImpactCityHandler())
+
+	testBackend.URL = testutil.ServerAddr
+	c := &Client{
+		B: testBackend,
+	}
+
+	fsidLookup := &firststreet.Lookup{
+		FSID: 1222175,
+	}
+
+	mvi, err := c.Lookup(firststreet.CityLocationType, fsidLookup)
+	assert.Nil(t, err)
+	assert.NotNil(t, mvi)
+	assert.Equal(t, mvi.FSID, int64(1222175))
+	assert.NotNil(t, mvi.Results)
+
+	fsidLookupBad := &firststreet.Lookup{}
+	_, err = c.Lookup(firststreet.CityLocationType, fsidLookupBad)
+	assert.NotNil(t, err)
+
+	latLngLookup := &firststreet.Lookup{
+		Lat: -43.23,
+		Lng: -23.12,
+	}
+
+	mvi, err = c.Lookup(firststreet.CityLocationType, latLngLookup)
+	assert.Nil(t, err)
+	assert.NotNil(t, mvi)
+	assert.Equal(t, mvi.FSID, int64(1222175))
+	assert.NotNil(t, mvi.Results)
+
+	addressLookup := &firststreet.Lookup{
+		Address: "Fernandina Beach FL",
+	}
+
+	mvi, err = c.Lookup(firststreet.CityLocationType, addressLookup)
+	assert.Nil(t, err)
+	assert.NotNil(t, mvi)
+	assert.Equal(t, mvi.FSID, int64(1222175))
 	assert.NotNil(t, mvi.Results)
 
 }

--- a/marketvalueimpact/fixtures/mvi-city.json
+++ b/marketvalueimpact/fixtures/mvi-city.json
@@ -1,0 +1,23 @@
+{
+  "FSID": 1222175,
+  "results": [{
+    "floodID": "kt",
+    "floodData": [{
+        "year": 2018,
+        "data": [{
+          "type": "loss_historic",
+          "unit": "dollars",
+          "value": -5993339.8641536
+        }]
+      },
+      {
+        "year": 2033,
+        "data": [{
+          "type": "loss_future",
+          "unit": "dollars",
+          "value": -6915392.15094647
+        }]
+      }
+    ]
+  }]
+}

--- a/tidal/client_test.go
+++ b/tidal/client_test.go
@@ -41,9 +41,8 @@ func tidalCityHandler() http.HandlerFunc {
 	})
 }
 func TestTidalLookupProperty(t *testing.T) {
-	testutil.Once.Do(func() {
-		testutil.StartServer(tidalPropertyHandler())
-	})
+	testutil.StartServer(tidalPropertyHandler())
+
 	testBackend.URL = testutil.ServerAddr
 	c := &Client{
 		B: testBackend,
@@ -87,22 +86,21 @@ func TestTidalLookupProperty(t *testing.T) {
 }
 
 func TestTidalLookupCity(t *testing.T) {
-	testutil.Once.Do(func() {
-		testutil.StartServer(tidalCityHandler())
-	})
+	testutil.StartServer(tidalCityHandler())
+
 	testBackend.URL = testutil.ServerAddr
 	c := &Client{
 		B: testBackend,
 	}
 
 	fsidLookup := &firststreet.Lookup{
-		FSID: 450350219571,
+		FSID: 4550875,
 	}
 
 	frd, err := c.Lookup(firststreet.CityLocationType, fsidLookup)
 	assert.Nil(t, err)
 	assert.NotNil(t, frd)
-	assert.Equal(t, frd.FSID, int64(450350219571))
+	assert.Equal(t, frd.FSID, int64(4550875))
 	assert.NotNil(t, frd.Results)
 
 	fsidLookupBad := &firststreet.Lookup{}
@@ -117,16 +115,16 @@ func TestTidalLookupCity(t *testing.T) {
 	frd, err = c.Lookup(firststreet.CityLocationType, latLngLookup)
 	assert.Nil(t, err)
 	assert.NotNil(t, frd)
-	assert.Equal(t, frd.FSID, int64(450350219571))
+	assert.Equal(t, frd.FSID, int64(4550875))
 	assert.NotNil(t, frd.Results)
 
 	addressLookup := &firststreet.Lookup{
-		Address: "1327 Autumn Drive Fernandina Beach FL",
+		Address: "Fernandina Beach FL",
 	}
 
 	frd, err = c.Lookup(firststreet.CityLocationType, addressLookup)
 	assert.Nil(t, err)
 	assert.NotNil(t, frd)
-	assert.Equal(t, frd.FSID, int64(450350219571))
+	assert.Equal(t, frd.FSID, int64(4550875))
 	assert.NotNil(t, frd.Results)
 }


### PR DESCRIPTION
- Adding tests for cityMVI
- Updating tests for city in other products
- Removing `testutil.Do.Once` as it only runs once and does not incorporate city data on products for city tests